### PR TITLE
add acryl-datahub[all] to big packages list

### DIFF
--- a/scenarios/big-packages.toml
+++ b/scenarios/big-packages.toml
@@ -227,3 +227,9 @@ python_version = "3.10"
 platform_system = "Linux"
 datetime = "2024-10-07T14:00:00"
 requirements = ["sktime[all-extras-pandas2]"]
+
+[acryl-datahub-all]
+python_version = "3.11"
+platform_system = "Linux"
+datetime = "2024-10-18T00:00:00"
+requirements = ["acryl-datahub[all]"]


### PR DESCRIPTION
acryl-datahub [1] contains many different extras for interactions with different data sources (postgres, S3, etc.).  All of them together is
>300 transitive dependencies and I think counts as "big" in the
context of dependency sets.

[1] https://pypi.org/project/acryl-datahub/